### PR TITLE
Fix 404 error caused by trailing forward slash

### DIFF
--- a/wiki/wiki.py
+++ b/wiki/wiki.py
@@ -333,8 +333,9 @@ def pages(page):
 @bp.route('/create/<article>')
 def create(article):
     article_f = formatPostLink(article)
+    redirect_url = 'create/%s' % article_f if article_f else 'create'
     if 'username' not in session.keys():
-        return redirect(url_for('wiki.hive_keychain_auth.login',redirect_url='create/'+article_f))
+        return redirect(url_for('wiki.hive_keychain_auth.login',redirect_url=redirect_url)
     if(session['userlevel'] < 1):
         return redirect('/insufficient_permissions') 
     if(article_f != article):


### PR DESCRIPTION
To reproduce the issue:

1. Start signed out on the home page https://propol.is/wiki/Welcome-To-Propolis-Wiki
2. click Create
3. navigates to https://propol.is/login/create/
4. do Keychain login
5. redirected to https://propol.is/create/
6. 404 not found "The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again."
7. 

The trailing forward slash is the problem. The destination should be https://propol.is/create